### PR TITLE
Add generics to schedule jobs

### DIFF
--- a/src/main/java/oncue/scheduler/JVMCapacityScheduler.java
+++ b/src/main/java/oncue/scheduler/JVMCapacityScheduler.java
@@ -40,7 +40,7 @@ import akka.actor.Cancellable;
  * broadcast) and then schedule jobs according to the memory capacity reported
  * by each agent.
  */
-public class JVMCapacityScheduler extends AbstractScheduler {
+public class JVMCapacityScheduler extends AbstractScheduler<JVMCapacityWorkRequest> {
 
 	// The list of work requests in this time window
 	List<JVMCapacityWorkRequest> workRequests = new ArrayList<>();
@@ -138,10 +138,10 @@ public class JVMCapacityScheduler extends AbstractScheduler {
 	}
 
 	@Override
-	protected void scheduleJobs(AbstractWorkRequest workRequest) {
+	protected void scheduleJobs(JVMCapacityWorkRequest workRequest) {
 
 		// Add to the map of unserviced work requests
-		workRequests.add((JVMCapacityWorkRequest) workRequest);
+		workRequests.add(workRequest);
 
 		/*
 		 * Give agents the specified amount of time to react to a jobs broadcast

--- a/src/main/java/oncue/scheduler/SimpleQueuePopScheduler.java
+++ b/src/main/java/oncue/scheduler/SimpleQueuePopScheduler.java
@@ -29,7 +29,7 @@ import oncue.scheduler.internal.Schedule;
  * This is strictly first-come-first-served: which ever agent makes the request
  * first will get the job.
  */
-public class SimpleQueuePopScheduler extends AbstractScheduler {
+public class SimpleQueuePopScheduler extends AbstractScheduler<AbstractWorkRequest> {
 
 	public SimpleQueuePopScheduler(Class<? extends BackingStore> backingStore) {
 		super(backingStore);

--- a/src/main/java/oncue/scheduler/ThrottledScheduler.java
+++ b/src/main/java/oncue/scheduler/ThrottledScheduler.java
@@ -36,19 +36,18 @@ import oncue.scheduler.internal.Schedule;
  * will pop just enough jobs off the queue to satisfy this throttled request for
  * work.
  */
-public class ThrottledScheduler extends AbstractScheduler {
+public class ThrottledScheduler extends AbstractScheduler<ThrottledWorkRequest> {
 
 	public ThrottledScheduler(Class<? extends BackingStore> backingStore) {
 		super(backingStore);
 	}
 
 	@Override
-	protected void scheduleJobs(AbstractWorkRequest workRequest) {
-		ThrottledWorkRequest throttledWorkRequest = (ThrottledWorkRequest) workRequest;
+	protected void scheduleJobs(ThrottledWorkRequest workRequest) {
 
 		// Pop the requested number of jobs
 		List<Job> jobs = new ArrayList<>();
-		for (int i = 0; i < throttledWorkRequest.getJobs(); i++) {
+		for (int i = 0; i < workRequest.getJobs(); i++) {
 			try {
 				jobs.add(unscheduledJobs.popJob());
 			} catch (NoJobsException e) {

--- a/src/main/java/oncue/scheduler/internal/AbstractScheduler.java
+++ b/src/main/java/oncue/scheduler/internal/AbstractScheduler.java
@@ -47,7 +47,7 @@ import akka.event.LoggingAdapter;
  * distributing the work using a variety of scheduling algorithms, depending on
  * the concrete implementation.
  */
-public abstract class AbstractScheduler extends UntypedActor {
+public abstract class AbstractScheduler<R extends AbstractWorkRequest> extends UntypedActor {
 
 	private ActorRef testProbe;
 	protected LoggingAdapter log = Logging.getLogger(getContext().system(), this);
@@ -251,6 +251,7 @@ public abstract class AbstractScheduler extends UntypedActor {
 						}, getContext().dispatcher());
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void onReceive(Object message) throws Exception {
 
@@ -278,7 +279,7 @@ public abstract class AbstractScheduler extends UntypedActor {
 			if (unscheduledJobs.getSize() == 0 || paused)
 				replyWithNoWork(getSender());
 			else
-				scheduleJobs((AbstractWorkRequest) message);
+				scheduleJobs((R) message);
 		}
 
 		else if (message instanceof JobProgress) {
@@ -380,7 +381,7 @@ public abstract class AbstractScheduler extends UntypedActor {
 	 * has been created, the work should be dispatched by calling the
 	 * <i>dispatchJobs</i> method.
 	 */
-	protected abstract void scheduleJobs(AbstractWorkRequest workRequest);
+	protected abstract void  scheduleJobs(R workRequest);
 
 	/**
 	 * Schedule a jobs broadcast. Cancel any previously scheduled broadcast, to


### PR DESCRIPTION
This commit changes `AbstractScheduler` to include a type parameter which specifies the type of work request a schedule will accept. 

Previously, concrete schedulers would perform a (possibly) unsafe cast in their `shceduleJobs` method, e.g. (line 144 of JVMCapacityScheduler):

   `workRequests.add((JVMCapacityWorkRequest) workRequest)` 

This cast now happens generically in `AbstractScheduler`, line 282:

  `scheduleJobs((R) message)`

As this line did not previously try to recover from a `ClassCastException`, I did not add a try/catch. However, if this exception could bring down the scheduler then this should be added (I'm too unfamiliar with akka to tell if this is an issue). 
