### PR TITLE
Allow workers to enqueue jobs with the specified queue manager

### DIFF
--- a/oncue-agent/pom.xml
+++ b/oncue-agent/pom.xml
@@ -28,27 +28,27 @@
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-remote_2.10</artifactId>
 			<version>2.1.0</version>
-		</dependency>				
+		</dependency>
 	</dependencies>
 
 	<build>
-	    <plugins>
+		<plugins>
 			<plugin>
-			    <groupId>org.apache.maven.plugins</groupId>
-			    <artifactId>maven-jar-plugin</artifactId>
-			    <configuration>
-			        <archive>
-			            <manifest>
-			                <addClasspath>true</addClasspath>
-			                <classpathPrefix>lib/</classpathPrefix>
-			                <mainClass>oncue.agent.OnCueAgent</mainClass>
-			            </manifest>
-			        </archive>
-			        <includes>
-			            <include>**</include>
-			        </includes>
-			    </configuration>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<configuration>
+					<archive>
+						<manifest>
+							<addClasspath>true</addClasspath>
+							<classpathPrefix>lib/</classpathPrefix>
+							<mainClass>oncue.agent.OnCueAgent</mainClass>
+						</manifest>
+					</archive>
+					<includes>
+						<include>**</include>
+					</includes>
+				</configuration>
 			</plugin>
-        </plugins>
-    </build>
+		</plugins>
+	</build>
 </project>

--- a/oncue-agent/src/main/java/oncue/agent/workers/AbstractWorker.java
+++ b/oncue-agent/src/main/java/oncue/agent/workers/AbstractWorker.java
@@ -1,39 +1,50 @@
 /*******************************************************************************
  * Copyright 2013 Michael Marconi
  * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  ******************************************************************************/
 package oncue.agent.workers;
 
+import static akka.pattern.Patterns.ask;
+
+import java.util.Map;
+
+import oncue.common.exceptions.EnqueueJobException;
+import oncue.common.messages.EnqueueJob;
 import oncue.common.messages.Job;
 import oncue.common.messages.JobProgress;
+import oncue.common.settings.Settings;
+import oncue.common.settings.SettingsProvider;
+import scala.concurrent.Await;
 import akka.actor.ActorRef;
 import akka.actor.UntypedActor;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
+import akka.pattern.AskTimeoutException;
+import akka.util.Timeout;
 
 public abstract class AbstractWorker extends UntypedActor {
 
-	protected LoggingAdapter log = Logging.getLogger(getContext().system(),
-			this);
+	protected LoggingAdapter log = Logging.getLogger(getContext().system(), this);
+
 	protected ActorRef agent;
+
 	protected Job job;
+
+	protected Settings settings = SettingsProvider.SettingsProvider.get(getContext().system());
 
 	/**
 	 * Begin working on a job immediately.
 	 * 
-	 * @param job
-	 *            is the specification for the work to be done
+	 * @param job is the specification for the work to be done
 	 */
 	protected abstract void doWork(Job job);
 
@@ -52,13 +63,11 @@ public abstract class AbstractWorker extends UntypedActor {
 	/**
 	 * Report on the percentage progress made on this job.
 	 * 
-	 * @param progress
-	 *            is a double, between 0 and 1
+	 * @param progress is a double, between 0 and 1
 	 */
-	public void reportProgress(double progress) {
+	protected void reportProgress(double progress) {
 		if (progress < 0 || progress > 1)
-			throw new RuntimeException(
-					"Job progress mut be reported as a double between 0 and 1");
+			throw new RuntimeException("Job progress must be reported as a double between 0 and 1");
 
 		agent.tell(new JobProgress(job, progress), getSelf());
 	}
@@ -66,8 +75,35 @@ public abstract class AbstractWorker extends UntypedActor {
 	/**
 	 * Indicate that work on this job is complete.
 	 */
-	public void workComplete() {
+	protected void workComplete() {
 		agent.tell(new JobProgress(job, 1), getSelf());
 		getContext().stop(getSelf());
+	}
+
+	/**
+	 * Submit the job to the specified queue manager.
+	 * 
+	 * @param workerType The qualified class name of the worker to instantiate
+	 * @param jobParameters The user-defined parameters map to pass to the job
+	 * @throws EnqueueJobException If the queue manager does not exist or the job is not accepted
+	 * within the timeout
+	 */
+	protected void enqueueJob(String workerType, Map<String, String> jobParameters)
+			throws EnqueueJobException {
+
+		try {
+			Await.result(
+					ask(getContext().actorFor(settings.QUEUE_MANAGER_PATH), new EnqueueJob(
+							workerType, jobParameters), new Timeout(settings.QUEUE_MANAGER_TIMEOUT)),
+					settings.QUEUE_MANAGER_TIMEOUT);
+		} catch (Exception e) {
+			if (e instanceof AskTimeoutException) {
+				log.error(e, "Timeout waiting for queue manager to enqueue job");
+			} else {
+				log.error(e, "Failed to enqueue job");
+			}
+
+			throw new EnqueueJobException(e);
+		}
 	}
 }

--- a/oncue-common/src/main/java/oncue/common/exceptions/EnqueueJobException.java
+++ b/oncue-common/src/main/java/oncue/common/exceptions/EnqueueJobException.java
@@ -1,0 +1,11 @@
+package oncue.common.exceptions;
+
+
+public class EnqueueJobException extends Exception {
+
+	private static final long serialVersionUID = 3389970447295029792L;
+
+	public EnqueueJobException(Throwable t) {
+		super(t);
+	}
+}

--- a/oncue-tests/src/test/java/oncue/tests/timedjobs/TimedJobTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/timedjobs/TimedJobTest.java
@@ -63,10 +63,10 @@ public class TimedJobTest extends AbstractActorSystemTest {
 						null);
 
 				// Expect two workers to send work responses
-				response = agentProbe.expectMsgClass(duration("2 seconds"), WorkResponse.class);
+				response = agentProbe.expectMsgClass(duration("4 seconds"), WorkResponse.class);
 				assertEquals(TestWorker.class.getName(), response.getJobs().get(0).getWorkerType());
 
-				response = agentProbe.expectMsgClass(duration("2 seconds"), WorkResponse.class);
+				response = agentProbe.expectMsgClass(duration("4 seconds"), WorkResponse.class);
 				assertEquals(TestWorker.class.getName(), response.getJobs().get(0).getWorkerType());
 			}
 		};
@@ -164,7 +164,7 @@ public class TimedJobTest extends AbstractActorSystemTest {
 				createQueueManager(system, null);
 
 				// Expect work response
-				response = agentProbe.expectMsgClass(duration("2 seconds"), WorkResponse.class);
+				response = agentProbe.expectMsgClass(duration("5 seconds"), WorkResponse.class);
 				Job job = response.getJobs().get(0);
 				assertEquals(TestWorker.class.getName(), job.getWorkerType());
 				assertEquals(null, job.getParams());

--- a/oncue-tests/src/test/java/oncue/tests/workers/JobEnqueueingTestWorker.java
+++ b/oncue-tests/src/test/java/oncue/tests/workers/JobEnqueueingTestWorker.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright 2013 Michael Marconi
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ ******************************************************************************/
+package oncue.tests.workers;
+
+import oncue.agent.workers.AbstractWorker;
+import oncue.common.messages.Job;
+
+public class JobEnqueueingTestWorker extends AbstractWorker {
+
+	@Override
+	public void doWork(Job job) {
+		try {
+			// Give this job to a test worker
+			Thread.sleep(500);
+
+			enqueueJob(TestWorker.class.getName(), job.getParams());
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+}


### PR DESCRIPTION
This change allows workers to enqueue jobs from inside themselves. This is useful when a worker performs its assigned task then wants another worker to continue.

I've also changed the visibility of some of the functions inside AbstractWorker, no need for them to be public.

Workers can now enqueue a job via `enqueueJob(String workerType, Map<String, String> jobParameters)`. This will wait for an acknowledgement from the Queue Manager, and will fail with an `EnqueueJobException` if no acknowledgement is received. The worker can then decide what to do with this information.
