### PR TITLE
Serialize `enqueuedAt` in ISO8061 format in Jobs JSON responses

### DIFF
--- a/oncue-backingstore/src/main/java/oncue/backingstore/RedisBackingStore.java
+++ b/oncue-backingstore/src/main/java/oncue/backingstore/RedisBackingStore.java
@@ -99,7 +99,7 @@ public class RedisBackingStore extends AbstractBackingStore {
 		Long jobId = redis.incr(RedisBackingStore.JOB_COUNT_KEY);
 
 		// Create a new job
-		Job job = new Job(jobId, DateTime.now(), workerType, jobParams);
+		Job job = new Job(jobId, workerType, jobParams);
 
 		// Now, persist the job and release the connection
 		persistJob(job, RedisBackingStore.NEW_JOBS, redis);

--- a/oncue-common/src/main/java/oncue/common/messages/Job.java
+++ b/oncue-common/src/main/java/oncue/common/messages/Job.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
 
 public class Job implements Serializable {
 
@@ -37,7 +38,11 @@ public class Job implements Serializable {
 	
 	public Job() {
 	}
-
+	
+	public Job(long id, String workerType, Map<String, String> params) {
+		this(id, new DateTime(DateTimeUtils.currentTimeMillis()), workerType, params);
+	}
+	
 	public Job(long id, DateTime enqueuedAt, String workerType) {
 		this(id, enqueuedAt, workerType, new HashMap<String, String>());
 	}

--- a/oncue-queuemanager/src/main/java/oncue/queuemanager/InMemoryQueueManager.java
+++ b/oncue-queuemanager/src/main/java/oncue/queuemanager/InMemoryQueueManager.java
@@ -19,8 +19,6 @@ import java.util.Map;
 
 import oncue.common.messages.Job;
 
-import org.joda.time.DateTime;
-
 /**
  * A simple, in-memory implementation of a queue manager. Since this queue
  * manager has no backing store, it immediately tells the scheduler about the
@@ -34,7 +32,7 @@ public class InMemoryQueueManager extends AbstractQueueManager {
 	protected Job createJob(String workerType, Map<String, String> jobParams) {
 
 		// Create a new job
-		Job job = new Job(getNextJobID(), DateTime.now(), workerType, jobParams);
+		Job job = new Job(getNextJobID(), workerType, jobParams);
 		
 		getLog().debug("Enqueueing {} for worker {}", job,  workerType);
 

--- a/oncue-service/app/controllers/api/Jobs.java
+++ b/oncue-service/app/controllers/api/Jobs.java
@@ -1,6 +1,9 @@
 package controllers.api;
 
 import static akka.pattern.Patterns.ask;
+
+import java.text.SimpleDateFormat;
+
 import oncue.common.messages.EnqueueJob;
 import oncue.common.messages.SimpleMessages.SimpleMessage;
 import oncue.common.settings.Settings;
@@ -23,7 +26,11 @@ public class Jobs extends Controller {
 
 	private final static Settings settings = SettingsProvider.SettingsProvider.get(Akka.system());
 	private final static ObjectMapper mapper = new ObjectMapper();
-
+	
+	static {
+		mapper.setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssz"));
+	}
+		
 	public static Result listJobs() {
 		ActorRef scheduler = Akka.system().actorFor(settings.SCHEDULER_PATH);
 		return async(Akka.asPromise(
@@ -81,7 +88,7 @@ public class Jobs extends Controller {
 					// Result objects are returned by the recover handler above
 					return (Result) response;
 				} else {
-					return ok(Json.toJson(response));
+					return ok(mapper.valueToTree(response));
 				}
 			}
 		}));

--- a/oncue-service/test/controllers/APITest.java
+++ b/oncue-service/test/controllers/APITest.java
@@ -22,6 +22,7 @@ import static play.test.Helpers.stop;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 import oncue.common.messages.EnqueueJob;
 import oncue.common.messages.Job;
@@ -30,7 +31,11 @@ import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParseException;
 import org.codehaus.jackson.map.JsonMappingException;
 import org.codehaus.jackson.map.ObjectMapper;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -44,16 +49,25 @@ public class APITest {
 	private final static FakeApplication fakeApplication = fakeApplication();
 	private final static ObjectMapper mapper = new ObjectMapper();
 
+	private DateTime expectedEnqueuedAt;
+
 	@BeforeClass
 	public static void startFakeApplication() {
 		start(fakeApplication);
+		DateTimeUtils.setCurrentMillisFixed(new DateTime(2013, 03, 27, 12, 34, 56).getMillis());
 	}
 
 	@AfterClass
 	public static void shutdownFakeApplication() {
 		stop(fakeApplication);
+		DateTimeUtils.setCurrentMillisSystem();
 	}
-
+	
+	@Before
+	public void setUp() {
+		expectedEnqueuedAt = new DateTime(2013, 03, 27, 12, 34, 56, DateTimeZone.forTimeZone(TimeZone.getDefault()));
+	}
+	
 	@Ignore
 	//TODO: fix this up
 	@Test
@@ -98,6 +112,7 @@ public class APITest {
 				Job.class);
 
 		assertEquals("oncue.test.TestWorker", job.getWorkerType());
+		assertTrue(expectedEnqueuedAt.isEqual(job.getEnqueuedAt()));
 		assertNotNull(job.getId());
 		assertEquals(0.0, job.getProgress());
 		assertTrue(job.getParams().isEmpty());
@@ -135,6 +150,7 @@ public class APITest {
 				Job.class);
 
 		assertEquals("oncue.test.TestWorker", job.getWorkerType());
+		assertTrue(expectedEnqueuedAt.isEqual(job.getEnqueuedAt()));
 		assertNotNull(job.getId());
 		assertEquals(0.0, job.getProgress());
 		assertEquals("Value 1", job.getParams().get("key1"));


### PR DESCRIPTION
The `enqueuedAt` field of the `Job` class is a joda `DateTime` object. By default this is being serialized as a long. This changes the serialization of `DateTime` object in the `Jobs` controller to use the ISO8061 format.
