### PR TITLE
Implement distributed timed job testing

### DIFF
--- a/oncue-scheduler/src/main/java/oncue/scheduler/AbstractScheduler.java
+++ b/oncue-scheduler/src/main/java/oncue/scheduler/AbstractScheduler.java
@@ -37,7 +37,6 @@ import oncue.common.settings.SettingsProvider;
 import org.joda.time.DateTime;
 
 import scala.concurrent.duration.Deadline;
-import sun.management.Agent;
 import akka.actor.ActorInitializationException;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;

--- a/oncue-tests/src/test/java/oncue/tests/base/DistributedActorSystemTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/base/DistributedActorSystemTest.java
@@ -140,7 +140,7 @@ public abstract class DistributedActorSystemTest {
 	public void stopActorSystems() throws Exception {
 		serviceSystem.shutdown();
 		agentSystem.shutdown();
-		while (!serviceSystem.isTerminated() && !agentSystem.isTerminated()) {
+		while (!serviceSystem.isTerminated() || !agentSystem.isTerminated()) {
 			serviceLog.debug("Waiting for systems to shut down...");
 			Thread.sleep(500);
 		}

--- a/oncue-tests/src/test/java/oncue/tests/load/DistributedThrottledLoadTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/load/DistributedThrottledLoadTest.java
@@ -19,12 +19,10 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import junit.framework.Assert;
-import oncue.agent.ThrottledAgent;
 import oncue.backingstore.RedisBackingStore;
 import oncue.common.messages.EnqueueJob;
 import oncue.common.messages.Job;
 import oncue.common.messages.JobProgress;
-import oncue.scheduler.ThrottledScheduler;
 import oncue.tests.base.DistributedActorSystemTest;
 import oncue.tests.load.workers.SimpleLoadTestWorker;
 

--- a/oncue-tests/src/test/java/oncue/tests/timedjobs/DistributedTimedJobTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/timedjobs/DistributedTimedJobTest.java
@@ -2,44 +2,94 @@ package oncue.tests.timedjobs;
 
 import java.util.Collections;
 
+import junit.framework.Assert;
+import oncue.backingstore.RedisBackingStore;
+import oncue.common.messages.Job;
+import oncue.common.messages.WorkResponse;
 import oncue.tests.base.DistributedActorSystemTest;
 import oncue.tests.load.workers.SimpleLoadTestWorker;
+import oncue.timedjobs.TimedJobFactory;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
+import redis.clients.jedis.Jedis;
 import akka.testkit.JavaTestKit;
 
-/**
- * @MF: go ahead and sort out this implementation. Ensure you're using a
- *      Throttled Scheduler + Agent if you're loading it up, as the unlimited
- *      strategy may behave weirdly with no constraints!
- */
 public class DistributedTimedJobTest extends DistributedActorSystemTest {
+
+	@After
+	@Before
+	public void flushRedis() {
+		Jedis redis = RedisBackingStore.getConnection();
+		redis.flushDB();
+		RedisBackingStore.releaseConnection(redis);
+	}
 
 	@Test
 	public void timedJobsWorkWithDistributedAgents() {
+		final JavaTestKit agentProbe = new JavaTestKit(agentSystem) {
 
-		// Create a scheduler probe
-		final JavaTestKit schedulerProbe = new JavaTestKit(serviceSystem) {
 			{
 				new IgnoreMsg() {
+
 					protected boolean ignore(Object message) {
+						if (message instanceof WorkResponse) {
+							return false;
+						}
+
 						return true;
 					}
 				};
 			}
 		};
 
-		// Create a queue manager
 		createQueueManager(null);
-
-		// Create a scheduler with a probe
-		createScheduler(schedulerProbe.getRef());
+		createScheduler(null);
 
 		// Create a throttled agent
-		createAgent(Collections.singletonList(SimpleLoadTestWorker.class.getName()), null);
+		createAgent(Collections.singletonList(SimpleLoadTestWorker.class.getName()),
+				agentProbe.getRef());
 
-		schedulerProbe.expectNoMsg();
+		// The agent should connect to the scheduler and get an empty work response
+		agentProbe.expectMsgClass(WorkResponse.class);
+
+		// Initialise timed jobs
+		TimedJobFactory.createTimedJobs(serviceSystem, serviceSettings.TIMED_JOBS_TIMETABLE);
+
+		// Wait until all the jobs have completed
+		final Jedis redis = RedisBackingStore.getConnection();
+
+		final int JOB_COUNT = serviceConfig.getInt("oncue.timed-jobs.repeatCount") + 1;
+
+		new JavaTestKit(serviceSystem) {
+			{
+				new AwaitCond(duration("5 minutes"), duration("10 seconds")) {
+
+					@Override
+					protected boolean cond() {
+						Job finalJob;
+						try {
+							finalJob = RedisBackingStore.loadJob(JOB_COUNT, redis);
+							return finalJob.getProgress() == 1.0;
+						} catch (RuntimeException e) {
+							// Job may not exist in Redis yet
+							return false;
+						}
+					}
+				};
+			}
+		};
+
+		// Now, check all the jobs completed in Redis
+		for (int i = 0; i < JOB_COUNT; i++) {
+			Job job = RedisBackingStore.loadJob(i + 1, redis);
+			Assert.assertEquals(1.0, job.getProgress());
+		}
+
+		serviceLog.info("All jobs were processed!");
+
+		RedisBackingStore.releaseConnection(redis);
 	}
-
 }

--- a/oncue-tests/src/test/resources/DistributedTimedJobTest-Agent.conf
+++ b/oncue-tests/src/test/resources/DistributedTimedJobTest-Agent.conf
@@ -1,5 +1,5 @@
 akka {
-	loglevel = DEBUG
+	loglevel = INFO
 	actor {
 		provider = "akka.remote.RemoteActorRefProvider"
 		guardian-supervisor-strategy = "oncue.common.supervisors.ServiceSupervisor"
@@ -16,7 +16,7 @@ akka {
 oncue {
 	agent {
 		class = "oncue.agent.ThrottledAgent"
-		throttled-agent.max-jobs = 1000
+		throttled-agent.max-jobs = 10
 	}
 	scheduler.path = "akka://oncue-service@localhost:9090"${oncue.scheduler.path}
 	queue-manager.path = "akka://oncue-service@localhost:9090"${oncue.queue-manager.path}

--- a/oncue-tests/src/test/resources/DistributedTimedJobTest-Service.conf
+++ b/oncue-tests/src/test/resources/DistributedTimedJobTest-Service.conf
@@ -1,4 +1,5 @@
 akka {
+	loglevel = INFO
 	actor {
 		provider = "akka.remote.RemoteActorRefProvider"
 		guardian-supervisor-strategy = "oncue.common.supervisors.ServiceSupervisor"				
@@ -9,5 +10,25 @@ akka {
         	hostname = "localhost"
 	        port = 9090
 		}
+	}
+}
+
+oncue {
+	scheduler {
+		class = "oncue.scheduler.ThrottledScheduler"
+		backing-store-class = "oncue.backingstore.RedisBackingStore"
+	}
+
+	// Run jobs on a timetable (See: http://camel.apache.org/quartz.html for URI format)
+	timed-jobs {
+		// Only for testing
+		repeatCount = 100
+		timetable = [
+			{
+				type = "oncue.tests.load.workers.SimpleLoadTestWorker"
+				name = "test-worker-timed-job"
+				endpointUri = "quartz://test-worker-timed-job?trigger.repeatInterval=100&trigger.repeatCount="${oncue.timed-jobs.repeatCount}"&fireNow=false" 
+			}
+		]
 	}
 }

--- a/oncue-tests/src/test/resources/TimedJobTest.conf
+++ b/oncue-tests/src/test/resources/TimedJobTest.conf
@@ -1,1 +1,1 @@
-oncue.timed-jobs.retry-delay = 1 seconds
+oncue.timed-jobs.retry-delay = 1 second

--- a/oncue-timedjobs/src/main/java/oncue/timedjobs/TimedJobFactory.java
+++ b/oncue-timedjobs/src/main/java/oncue/timedjobs/TimedJobFactory.java
@@ -15,7 +15,7 @@ import akka.actor.UntypedActorFactory;
 public class TimedJobFactory {
 
 	@SuppressWarnings("unchecked")
-	public static void createJobsFromJobMap(ActorSystem system, List<Map<String, Object>> jobList,
+	public static void createTimedJobs(ActorSystem system, List<Map<String, Object>> jobList,
 			ActorRef testingProbe) {
 		for (Map<String, Object> jobMap : jobList) {
 			String name = (String) jobMap.get("name");
@@ -38,7 +38,7 @@ public class TimedJobFactory {
 	}
 
 	public static void createTimedJobs(ActorSystem system, List<Map<String, Object>> jobList) {
-		createJobsFromJobMap(system, jobList, null);
+		createTimedJobs(system, jobList, null);
 	}
 
 	@SuppressWarnings("serial")
@@ -56,6 +56,11 @@ public class TimedJobFactory {
 		}), "job-timer-" + jobName);
 	}
 
+	public static void createTimedJob(ActorSystem system, final String workerType,
+			final String jobName, final String endpointUri, final Map<String, String> parameters, ActorRef testProbe) {
+		createTimedJob(system, workerType, jobName, endpointUri, parameters, null, testProbe);
+	}
+	
 	public static void createTimedJob(ActorSystem system, final String workerType,
 			final String jobName, final String endpointUri, final Map<String, String> parameters) {
 		createTimedJob(system, workerType, jobName, endpointUri, parameters, null, null);


### PR DESCRIPTION
This contains the following changes: 

Fix logic that would wait for only one actor system to shut down before continuing

Implement test for timed jobs on distributed actor systems

Improve testing by querying redis rather than expecting messages

Improve failing timed job tests that don't wait for camel to start

Reduce log level in timed job tests
