### PR TITLE
Change defaults to throttled strategy out of the box

### DIFF
--- a/oncue-common/src/main/resources/reference.conf
+++ b/oncue-common/src/main/resources/reference.conf
@@ -12,8 +12,7 @@ oncue {
 	scheduler {
 		name = "scheduler"
 		path = "/user/scheduler"
-		class = "oncue.scheduler.SimpleQueuePopScheduler"
-		// class = "oncue.scheduler.ThrottledScheduler"
+		class = "oncue.scheduler.ThrottledScheduler"
 		
 		// Uncomment the following to use the persistent Redis Backing Store		
 		// backing-store-class = "oncue.backingstore.RedisBackingStore"
@@ -40,9 +39,8 @@ oncue {
 	}
 	
 	agent {
-		class = "oncue.agent.UnlimitedCapacityAgent"
-		// class = "oncue.agent.ThrottledAgent"
-		// throttled-agent.max-jobs = 10
+		class = "oncue.agent.ThrottledAgent"
+		throttled-agent.max-jobs = 1
 		name = "agent"
 		path = "/user/agent"
 		

--- a/oncue-tests/src/test/resources/reference.conf
+++ b/oncue-tests/src/test/resources/reference.conf
@@ -13,3 +13,8 @@ akka {
 		log-remote-lifecycle-events = off 
 	}
 }
+
+oncue {
+	scheduler.class = "oncue.scheduler.SimpleQueuePopScheduler"
+	agent.class = "oncue.agent.UnlimitedCapacityAgent"
+}


### PR DESCRIPTION
This changes the default strategy to a throttled one, rather than unlimited capacity out of the box.

Fixes #32.
