### PR TITLE
Allow custom deploy.conf configurations for the oncue service component

### DIFF
--- a/oncue-common/src/main/resources/reference.conf
+++ b/oncue-common/src/main/resources/reference.conf
@@ -1,59 +1,60 @@
 oncue {
 	queue-manager {
 		class = "oncue.queuemanager.InMemoryQueueManager"
-		// class = "oncue.queueManager.RedisQueueManager"				
+		// class = "oncue.queuemanager.RedisQueueManager"
 		name = "queue-manager"
 		path = "/user/queue-manager"
-		
-		// The amount of time to wait for a queue manager response		
+
+		// The amount of time to wait for a queue manager response
 		timeout = 2 seconds
 	}
-	
+
 	scheduler {
 		name = "scheduler"
 		path = "/user/scheduler"
+
 		class = "oncue.scheduler.ThrottledScheduler"
-		
-		// Uncomment the following to use the persistent Redis Backing Store		
+		// class = "oncue.scheduler.SimpleQueuePopScheduler"
+
+		// Uncomment the following to use the persistent Redis Backing Store
 		// backing-store-class = "oncue.backingstore.RedisBackingStore"
-		
+
 		// The frequency with which unscheduled jobs are broadcast
 		broadcast-jobs-frequency = 5 seconds
-		
+
 		// Time to wait after a new job has arrived before broadcasting jobs
 		broadcast-jobs-quiescence-period = 1 second
-		
+
 		// The frequency with which agents are monitored for death
 		monitor-agents-frequency = 5 seconds
-		
+
 		// The timeout before an agent is deemed to be dead
 		agent-heartbeat-timeout = 15 seconds
 	}
-	
+
 	timed-jobs {
 		// The amount of time to wait before retrying a timed job
 		retry-delay = 10 seconds
-				
+
 		// No timed jobs by default
 		timetable = []
 	}
-	
+
 	agent {
 		class = "oncue.agent.ThrottledAgent"
 		throttled-agent.max-jobs = 1
 		name = "agent"
 		path = "/user/agent"
-		
+
 		scheduler-path = "/user/scheduler"
-		
-		// The frequenct of agent heartbeats		
+
+		// The frequenct of agent heartbeats
 		heartbeat-frequency = 5 seconds	
-		
-		
+
 		// No worker classes by default
 		workers = []
 	}
-	
+
 	api {
 		name = "api"
 		timeout = 2 seconds

--- a/oncue-service/conf/.gitignore
+++ b/oncue-service/conf/.gitignore
@@ -1,0 +1,1 @@
+deploy.conf

--- a/oncue-service/conf/application.conf
+++ b/oncue-service/conf/application.conf
@@ -85,4 +85,5 @@ akka {
 	}
 }
 
-
+# Include deployment configuration
+include "deploy.conf"


### PR DESCRIPTION
This allows users to provide custom deploy configurations on top of the out-of-the-box `application.conf` provided by `oncue-service`.

Adding a `deploy.conf` in the `conf` directory (`.gitignore`d) allows you to add deployment specific changes without having to store the contents of `oncue-service`'s `application.conf` and overwrite it with your own settings.
