### PR TITLE
Force explicit work completion

### DIFF
--- a/oncue-agent/src/main/java/oncue/agent/ThrottledAgent.java
+++ b/oncue-agent/src/main/java/oncue/agent/ThrottledAgent.java
@@ -52,6 +52,9 @@ public class ThrottledAgent extends AbstractAgent {
 			int jobsToRequest = MAX_WORKERS - jobsInProgress.size();
 			log.debug("Requesting {} new jobs", jobsToRequest);
 			getScheduler().tell(new ThrottledWorkRequest(getSelf(), getWorkerTypes(), jobsToRequest), getSelf());
+		} else {
+			log.debug("Not requesting work because {} jobs in progress and limited to {} workers", 
+					jobsInProgress.size(), MAX_WORKERS);
 		}
 	}
 }

--- a/oncue-tests/src/test/java/oncue/tests/load/workers/SimpleLoadTestWorker.java
+++ b/oncue-tests/src/test/java/oncue/tests/load/workers/SimpleLoadTestWorker.java
@@ -23,7 +23,7 @@ public class SimpleLoadTestWorker extends AbstractWorker {
 	private static final int LOAD_FACTOR = 10000;
 
 	@Override
-	protected void doWork(Job job) {
+	protected JobState doWork(Job job) {
 
 		int count = 0;
 		while (count < LOAD_FACTOR) {
@@ -37,7 +37,7 @@ public class SimpleLoadTestWorker extends AbstractWorker {
 				Thread.yield();
 		}
 
-		workComplete();
+		return JobState.COMPLETE;
 	}
 
 }

--- a/oncue-tests/src/test/java/oncue/tests/workers/IncompetentTestWorker.java
+++ b/oncue-tests/src/test/java/oncue/tests/workers/IncompetentTestWorker.java
@@ -24,7 +24,7 @@ import oncue.worker.AbstractWorker;
 public class IncompetentTestWorker extends AbstractWorker {
 
 	@Override
-	public void doWork(Job job) {
+	public JobState doWork(Job job) {
 		double progress = 0.0;
 		for (int i = 0; i < 3; i++) {
 			progress += 0.25;
@@ -44,6 +44,6 @@ public class IncompetentTestWorker extends AbstractWorker {
 				e.printStackTrace();
 			}
 		}
-		workComplete();
+		return JobState.COMPLETE;
 	}
 }

--- a/oncue-tests/src/test/java/oncue/tests/workers/JobEnqueueingTestWorker.java
+++ b/oncue-tests/src/test/java/oncue/tests/workers/JobEnqueueingTestWorker.java
@@ -19,7 +19,7 @@ import oncue.worker.AbstractWorker;
 public class JobEnqueueingTestWorker extends AbstractWorker {
 
 	@Override
-	public void doWork(Job job) {
+	public JobState doWork(Job job) {
 		try {
 			// Give this job to a test worker
 			Thread.sleep(500);
@@ -28,5 +28,7 @@ public class JobEnqueueingTestWorker extends AbstractWorker {
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
+
+		return JobState.COMPLETE;
 	}
 }

--- a/oncue-tests/src/test/java/oncue/tests/workers/TestWorker.java
+++ b/oncue-tests/src/test/java/oncue/tests/workers/TestWorker.java
@@ -21,7 +21,7 @@ import oncue.worker.AbstractWorker;
 public class TestWorker extends AbstractWorker {
 
 	@Override
-	public void doWork(Job job) {
+	public JobState doWork(Job job) {
 		double progress = 0.0;
 		for (int i = 0; i < 3; i++) {
 			progress += 0.25;
@@ -32,7 +32,7 @@ public class TestWorker extends AbstractWorker {
 				e.printStackTrace();
 			}
 		}
-		workComplete();
+		return JobState.COMPLETE;
 	}
 
 }

--- a/oncue-worker/src/main/java/oncue/worker/SampleWorker.java
+++ b/oncue-worker/src/main/java/oncue/worker/SampleWorker.java
@@ -23,7 +23,7 @@ import oncue.common.messages.Job;
 public class SampleWorker extends AbstractWorker {
 
 	@Override
-	protected void doWork(Job job) {
+	protected JobState doWork(Job job) {
 		double progress = 0.0;
 		System.out.print("Sample worker doing work on Job " + job.getId() + ".");
 		for (int i = 0; i < 3; i++) {
@@ -37,7 +37,8 @@ public class SampleWorker extends AbstractWorker {
 			}
 		}
 		System.out.println("Complete!");
-		workComplete();
+
+		return JobState.COMPLETE;
 	}
 
 }


### PR DESCRIPTION
Before, `workComplete()` had to be called by descendants of `AbstractWorker`; otherwise the worker hung around. But it's easy to forget to call `workComplete`, and turn into a zombie by accident.

By making `AbstractWorker.doWork` return an enumeration, the descendants of `AbstractWorker` need to be explicit about whether work is complete, or work is in progress and the worker should continue to live.
