### PR TITLE
Redis connection is now configurable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,10 @@ branches:
     - master
 services:
   - redis-server
+
+env:
+- PLAY_VERSION=2.1.0
+
+before_script:
+- wget http://download.playframework.org/releases/play-${PLAY_VERSION}.zip
+- unzip -q play-${PLAY_VERSION}.zip

--- a/oncue-common/src/main/java/oncue/common/settings/Settings.java
+++ b/oncue-common/src/main/java/oncue/common/settings/Settings.java
@@ -64,7 +64,7 @@ public class Settings implements Extension {
 		SCHEDULER_TIMEOUT = Duration.create(config.getMilliseconds("scheduler.response-timeout"), TimeUnit.MILLISECONDS);
 
 		try {
-			SCHEDULER_BACKING_STORE_CLASS = config.getString("scheduler.backing-store-class");
+			SCHEDULER_BACKING_STORE_CLASS = config.getString("scheduler.backing-store.class");
 		} catch (ConfigException.Missing e) {
 			SCHEDULER_BACKING_STORE_CLASS = null;
 		}

--- a/oncue-common/src/main/resources/reference.conf
+++ b/oncue-common/src/main/resources/reference.conf
@@ -16,8 +16,14 @@ oncue {
 		class = "oncue.scheduler.ThrottledScheduler"
 		// class = "oncue.scheduler.SimpleQueuePopScheduler"
 
-		// Uncomment the following to use the persistent Redis Backing Store
-		// backing-store-class = "oncue.backingstore.RedisBackingStore"
+		backing-store {
+			// Uncomment the following to use the persistent Redis Backing Store
+			// class = "oncue.backingstore.RedisBackingStore"
+			// redis {
+			//  	host = "localhost"
+			//  	port = 6379			
+			// }
+		}
 		
 		// The amount of time to wait for a queue manager response		
 		response-timeout = 2 seconds		

--- a/oncue-tests/pom.xml
+++ b/oncue-tests/pom.xml
@@ -66,6 +66,16 @@
 		</dependency>
 	</dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.14.1</version>
+			</plugin>
+		</plugins>
+	</build>
+
 	<reporting>
 		<plugins>
 			<plugin>
@@ -75,13 +85,4 @@
 			</plugin>
 		</plugins>
 	</reporting>
-
-	<build>
-
-		<!-- <plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-surefire-plugin</artifactId> 
-			<version>2.13</version> <configuration> <excludes> <exclude>**/oncue-service/**</exclude> 
-			<exclude>**/load/**</exclude> </excludes> </configuration> </plugin> <plugins> 
-			<plugin> <groupId>org.apache.maven.plugins</groupId> <artifactId>maven-surefire-report-plugin</artifactId> 
-			<version>2.6</version> </plugin> </plugins> -->
-	</build>
 </project>

--- a/oncue-tests/src/test/java/oncue/tests/load/DistributedThrottledLoadTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/load/DistributedThrottledLoadTest.java
@@ -50,7 +50,7 @@ public class DistributedThrottledLoadTest extends DistributedActorSystemTest {
 	private static final int JOB_COUNT = 20000;
 
 	@Test
-	public void throttledLoadTest() {
+	public void distributedThrottledLoadTest() {
 
 		// Create a queue manager probe
 		final JavaTestKit queueManagerProbe = new JavaTestKit(serviceSystem);

--- a/oncue-tests/src/test/java/oncue/tests/redis/RedisBackingStoreTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/redis/RedisBackingStoreTest.java
@@ -247,87 +247,104 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 
 	@Test
 	public void popUnscheduledJob() {
-		Jedis redis = RedisBackingStore.getConnection();
-		RedisBackingStore backingStore = new RedisBackingStore(null, null);
+		new JavaTestKit(system) {
+			{
+				Jedis redis = RedisBackingStore.getConnection();
+				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
-		// Push a job into Redis
-		Job job = new Job(1, DateTime.now(), TestWorker.class.getName());
-		RedisBackingStore.persistJob(job, RedisBackingStore.UNSCHEDULED_JOBS, redis);
+				// Push a job into Redis
+				Job job = new Job(1, DateTime.now(), TestWorker.class.getName());
+				RedisBackingStore.persistJob(job, RedisBackingStore.UNSCHEDULED_JOBS, redis);
 
-		long jobID = backingStore.popUnscheduledJob();
-		Job poppedJob = RedisBackingStore.loadJob(jobID, redis);
+				long jobID = backingStore.popUnscheduledJob();
+				Job poppedJob = RedisBackingStore.loadJob(jobID, redis);
 
-		assertEquals(job.getId(), poppedJob.getId());
-		assertEquals(job.getEnqueuedAt().toString(), poppedJob.getEnqueuedAt().toString());
-		assertEquals(job.getWorkerType(), poppedJob.getWorkerType());
+				assertEquals(job.getId(), poppedJob.getId());
+				assertEquals(job.getEnqueuedAt().toString(), poppedJob.getEnqueuedAt().toString());
+				assertEquals(job.getWorkerType(), poppedJob.getWorkerType());
 
-		RedisBackingStore.releaseConnection(redis);
+				RedisBackingStore.releaseConnection(redis);
+			}
+		};
 	}
 
 	@Test
 	public void removeScheduledJob() {
-		Jedis redis = RedisBackingStore.getConnection();
-		RedisBackingStore backingStore = new RedisBackingStore(null, null);
+		new JavaTestKit(system) {
+			{
+				Jedis redis = RedisBackingStore.getConnection();
+				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
-		// Push a job into Redis
-		Job job = new Job(1, DateTime.now(), TestWorker.class.getName());
-		RedisBackingStore.persistJob(job, RedisBackingStore.SCHEDULED_JOBS, redis);
+				// Push a job into Redis
+				Job job = new Job(1, DateTime.now(), TestWorker.class.getName());
+				RedisBackingStore.persistJob(job, RedisBackingStore.SCHEDULED_JOBS, redis);
 
-		// Remove the scheduled job
-		backingStore.removeScheduledJob(job);
+				// Remove the scheduled job
+				backingStore.removeScheduledJob(job);
 
-		// Check scheduled list in Redis
-		assertEquals("Expected no jobs in the scheduled jobs list", 0,
-				redis.lrange(RedisBackingStore.SCHEDULED_JOBS, 0, -1).size());
+				// Check scheduled list in Redis
+				assertEquals("Expected no jobs in the scheduled jobs list", 0,
+						redis.lrange(RedisBackingStore.SCHEDULED_JOBS, 0, -1).size());
 
-		RedisBackingStore.releaseConnection(redis);
+				RedisBackingStore.releaseConnection(redis);
+			}
+		};
 	}
 
 	@Test
 	public void removeUnscheduledJob() {
-		Jedis redis = RedisBackingStore.getConnection();
-		RedisBackingStore backingStore = new RedisBackingStore(null, null);
+		new JavaTestKit(system) {
+			{
+				Jedis redis = RedisBackingStore.getConnection();
+				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
-		// Push a job into Redis
-		Job job = new Job(1, DateTime.now(), TestWorker.class.getName());
-		RedisBackingStore.persistJob(job, RedisBackingStore.UNSCHEDULED_JOBS, redis);
+				// Push a job into Redis
+				Job job = new Job(1, DateTime.now(), TestWorker.class.getName());
+				RedisBackingStore.persistJob(job, RedisBackingStore.UNSCHEDULED_JOBS, redis);
 
-		// Remove the scheduled job
-		backingStore.removeUnscheduledJob(job);
+				// Remove the scheduled job
+				backingStore.removeUnscheduledJob(job);
 
-		// Check scheduled list in Redis
-		assertEquals("Expected no jobs in the unscheduled jobs list", 0,
-				redis.lrange(RedisBackingStore.UNSCHEDULED_JOBS, 0, -1).size());
+				// Check scheduled list in Redis
+				assertEquals("Expected no jobs in the unscheduled jobs list", 0,
+						redis.lrange(RedisBackingStore.UNSCHEDULED_JOBS, 0, -1).size());
 
-		RedisBackingStore.releaseConnection(redis);
+				RedisBackingStore.releaseConnection(redis);
+
+			}
+		};
 	}
 
 	@Test
 	public void restoreJobs() {
-		Jedis redis = RedisBackingStore.getConnection();
-		RedisBackingStore backingStore = new RedisBackingStore(null, null);
+		new JavaTestKit(system) {
+			{
+				Jedis redis = RedisBackingStore.getConnection();
+				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
-		// Push an unscheduled job into Redis
-		Job unscheduledJob = new Job(1, DateTime.now(), TestWorker.class.getName());
-		RedisBackingStore.persistJob(unscheduledJob, RedisBackingStore.UNSCHEDULED_JOBS, redis);
+				// Push an unscheduled job into Redis
+				Job unscheduledJob = new Job(1, DateTime.now(), TestWorker.class.getName());
+				RedisBackingStore.persistJob(unscheduledJob, RedisBackingStore.UNSCHEDULED_JOBS, redis);
 
-		// Push a scheduled job into Redis
-		Job scheduledJob = new Job(2, DateTime.now(), TestWorker.class.getName());
-		RedisBackingStore.persistJob(scheduledJob, RedisBackingStore.SCHEDULED_JOBS, redis);
+				// Push a scheduled job into Redis
+				Job scheduledJob = new Job(2, DateTime.now(), TestWorker.class.getName());
+				RedisBackingStore.persistJob(scheduledJob, RedisBackingStore.SCHEDULED_JOBS, redis);
 
-		// Restore the jobs
-		List<Job> restoredJobs = backingStore.restoreJobs();
+				// Restore the jobs
+				List<Job> restoredJobs = backingStore.restoreJobs();
 
-		// Check the set of restored jobs
-		assertTrue(restoredJobs.size() == 2);
-		for (Job job : restoredJobs) {
-			assertTrue(job.getId() == unscheduledJob.getId() || job.getId() == scheduledJob.getId());
-		}
+				// Check the set of restored jobs
+				assertTrue(restoredJobs.size() == 2);
+				for (Job job : restoredJobs) {
+					assertTrue(job.getId() == unscheduledJob.getId() || job.getId() == scheduledJob.getId());
+				}
 
-		// Make sure no scheduled jobs remain
-		assertEquals(0, redis.lrange(RedisBackingStore.SCHEDULED_JOBS, 0, -1).size());
+				// Make sure no scheduled jobs remain
+				assertEquals(0, redis.lrange(RedisBackingStore.SCHEDULED_JOBS, 0, -1).size());
 
-		RedisBackingStore.releaseConnection(redis);
+				RedisBackingStore.releaseConnection(redis);
+			}
+		};
 	}
 
 	@Test

--- a/oncue-tests/src/test/resources/DistributedThrottledLoadTest-Service.conf
+++ b/oncue-tests/src/test/resources/DistributedThrottledLoadTest-Service.conf
@@ -15,5 +15,5 @@ akka {
 
 oncue.scheduler {
 	class = "oncue.scheduler.ThrottledScheduler"
-	backing-store-class = "oncue.backingstore.RedisBackingStore"
+	backing-store.class = "oncue.backingstore.RedisBackingStore"
 }

--- a/oncue-tests/src/test/resources/DistributedTimedJobTest-Service.conf
+++ b/oncue-tests/src/test/resources/DistributedTimedJobTest-Service.conf
@@ -16,7 +16,7 @@ oncue {
 	queue-manager.class = "oncue.queuemanager.RedisQueueManager"
 	scheduler {
 		class = "oncue.scheduler.ThrottledScheduler"
-		backing-store-class = "oncue.backingstore.RedisBackingStore"
+		backing-store.class = "oncue.backingstore.RedisBackingStore"
 	}
 
 	// Run jobs on a timetable (See: http://camel.apache.org/quartz.html for URI format)

--- a/oncue-tests/src/test/resources/RedisBackingStoreTest.conf
+++ b/oncue-tests/src/test/resources/RedisBackingStoreTest.conf
@@ -1,1 +1,1 @@
-oncue.scheduler.backing-store-class = "oncue.backingstore.RedisBackingStore"
+oncue.scheduler.backing-store.class = "oncue.backingstore.RedisBackingStore"

--- a/oncue-tests/src/test/resources/RobustRedisDequeueTest.conf
+++ b/oncue-tests/src/test/resources/RobustRedisDequeueTest.conf
@@ -1,2 +1,2 @@
 oncue.queue-manager.class = "oncue.queuemanager.RedisQueueManager"
-oncue.scheduler.backing-store-class = "oncue.backingstore.RedisBackingStore"
+oncue.scheduler.backing-store.class = "oncue.backingstore.RedisBackingStore"

--- a/oncue-tests/src/test/resources/SchedulerDiesTest.conf
+++ b/oncue-tests/src/test/resources/SchedulerDiesTest.conf
@@ -1,1 +1,1 @@
-oncue.scheduler.backing-store-class = "oncue.backingstore.RedisBackingStore"
+oncue.scheduler.backing-store.class = "oncue.backingstore.RedisBackingStore"

--- a/oncue-tests/src/test/resources/ThrottledLoadTest.conf
+++ b/oncue-tests/src/test/resources/ThrottledLoadTest.conf
@@ -1,7 +1,7 @@
 oncue {
 	scheduler {
 		class = "oncue.scheduler.ThrottledScheduler"
-		backing-store-class = "oncue.backingstore.RedisBackingStore"
+		backing-store.class = "oncue.backingstore.RedisBackingStore"
 	}
 	agent {
 		class = "oncue.agent.ThrottledAgent"


### PR DESCRIPTION
You can now specify the Redis host and port in the configuration.  Look out for the confirmation in the log output.

See `scheduler.backing-store` configuration in `/oncue-common/src/main/resources/reference.conf`.

This resolves #39 
