### PR TITLE
Exclude junit.junit.* from org.jsonsimple in the pom.

### DIFF
--- a/oncue-agent/pom.xml
+++ b/oncue-agent/pom.xml
@@ -53,6 +53,12 @@
 			<groupId>com.googlecode.json-simple</groupId>
 			<artifactId>json-simple</artifactId>
 			<version>1.1.1</version>
+			<exclusions>
+				<exclusion>
+					 <groupId>junit</groupId>
+					<artifactId>junit</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/oncue-backingstore/pom.xml
+++ b/oncue-backingstore/pom.xml
@@ -23,14 +23,20 @@
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
       <version>1.1.1</version>
-    </dependency>   
+      <exclusions>
+        <exclusion>
+           <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
       <version>2.0.0</version>
       <type>jar</type>
       <scope>compile</scope>
-    </dependency>      
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
This excludes junit.junit.\* from the json-simple implementation as it is included in the wrong scope in that project.

This has been corrected at the source finally but no release has happened yet so we can't take advantage of it.

See: http://code.google.com/p/json-simple/issues/detail?id=75
