### PR TITLE
Fix timed job tests

### DIFF
--- a/oncue-service/test/controllers/APITest.java
+++ b/oncue-service/test/controllers/APITest.java
@@ -7,7 +7,6 @@ import static org.fest.assertions.Assertions.assertThat;
 import static play.mvc.Http.Status.OK;
 import static play.test.Helpers.GET;
 import static play.test.Helpers.POST;
-import static play.test.Helpers.PUT;
 import static play.test.Helpers.charset;
 import static play.test.Helpers.contentAsString;
 import static play.test.Helpers.contentType;


### PR DESCRIPTION
Fixes #65. I'm not entirely sure how these tests worked, as they didn't really do what they said they were doing on the tin.
