### PR TITLE
Fix jobs not being cleaned in redis backing store

### DIFF
--- a/oncue-agent/pom.xml
+++ b/oncue-agent/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>oncue</groupId>
 		<artifactId>oncue</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oncue-agent</artifactId>
@@ -17,12 +17,12 @@
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-common</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-worker</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>

--- a/oncue-backingstore/pom.xml
+++ b/oncue-backingstore/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>oncue</groupId>
     <artifactId>oncue</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>oncue-backingstore</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>oncue</groupId>
       <artifactId>oncue-common</artifactId>
-      <version>1.0.2-SNAPSHOT</version>
+      <version>1.0.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>

--- a/oncue-backingstore/src/main/java/oncue/backingstore/RedisBackingStore.java
+++ b/oncue-backingstore/src/main/java/oncue/backingstore/RedisBackingStore.java
@@ -385,6 +385,7 @@ public class RedisBackingStore extends AbstractBackingStore {
 		Jedis redis = RedisBackingStore.getConnection();
 
 		redis.lrem(COMPLETED_JOBS, 0, Long.toString(jobId));
+		removeJobById(jobId, redis);
 
 		RedisBackingStore.releaseConnection(redis);
 	}
@@ -394,6 +395,7 @@ public class RedisBackingStore extends AbstractBackingStore {
 		Jedis redis = RedisBackingStore.getConnection();
 
 		redis.lrem(FAILED_JOBS, 0, Long.toString(jobId));
+		removeJobById(jobId, redis);
 
 		RedisBackingStore.releaseConnection(redis);
 	}
@@ -403,6 +405,7 @@ public class RedisBackingStore extends AbstractBackingStore {
 		Jedis redis = RedisBackingStore.getConnection();
 
 		redis.lrem(SCHEDULED_JOBS, 0, Long.toString(jobId));
+		removeJobById(jobId, redis);
 
 		RedisBackingStore.releaseConnection(redis);
 	}
@@ -412,8 +415,13 @@ public class RedisBackingStore extends AbstractBackingStore {
 		Jedis redis = RedisBackingStore.getConnection();
 
 		redis.lrem(UNSCHEDULED_JOBS, 0, Long.toString(jobId));
+		removeJobById(jobId, redis);
 
 		RedisBackingStore.releaseConnection(redis);
+	}
+
+	public void removeJobById(long jobId, Jedis redis) {
+		redis.del(String.format(JOB_KEY, jobId));
 	}
 
 	/**

--- a/oncue-backingstore/src/main/java/oncue/backingstore/RedisBackingStore.java
+++ b/oncue-backingstore/src/main/java/oncue/backingstore/RedisBackingStore.java
@@ -405,7 +405,6 @@ public class RedisBackingStore extends AbstractBackingStore {
 		Jedis redis = RedisBackingStore.getConnection();
 
 		redis.lrem(SCHEDULED_JOBS, 0, Long.toString(jobId));
-		removeJobById(jobId, redis);
 
 		RedisBackingStore.releaseConnection(redis);
 	}
@@ -415,7 +414,6 @@ public class RedisBackingStore extends AbstractBackingStore {
 		Jedis redis = RedisBackingStore.getConnection();
 
 		redis.lrem(UNSCHEDULED_JOBS, 0, Long.toString(jobId));
-		removeJobById(jobId, redis);
 
 		RedisBackingStore.releaseConnection(redis);
 	}

--- a/oncue-client/pom.xml
+++ b/oncue-client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>oncue</artifactId>
     <groupId>oncue</groupId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
   </parent>
   <groupId>oncue</groupId>
   <artifactId>oncue-client</artifactId>
@@ -25,7 +25,7 @@
 	<dependency>
 	  <groupId>oncue</groupId>
 	  <artifactId>oncue-common</artifactId>
-	  <version>1.0.2-SNAPSHOT</version>
+	  <version>1.0.3-SNAPSHOT</version>
 	</dependency>
 	<dependency>
   		<groupId>com.fasterxml.jackson.core</groupId>

--- a/oncue-common/pom.xml
+++ b/oncue-common/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>oncue</groupId>
 		<artifactId>oncue</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oncue-common</artifactId>

--- a/oncue-scheduler/pom.xml
+++ b/oncue-scheduler/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>oncue</groupId>
     <artifactId>oncue</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>oncue-scheduler</artifactId>
@@ -17,12 +17,12 @@
     <dependency>
       <groupId>oncue</groupId>
       <artifactId>oncue-common</artifactId>
-      <version>1.0.2-SNAPSHOT</version>
+      <version>1.0.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>oncue</groupId>
       <artifactId>oncue-backingstore</artifactId>
-      <version>1.0.2-SNAPSHOT</version>
+      <version>1.0.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>

--- a/oncue-service/pom.xml
+++ b/oncue-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>oncue</groupId>
 		<artifactId>oncue</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>oncue-service</artifactId>
@@ -28,17 +28,17 @@
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-common</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-scheduler</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-timedjobs</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 		</dependency>
 
 		<!-- Play Framework Dependencies -->

--- a/oncue-service/project/Build.scala
+++ b/oncue-service/project/Build.scala
@@ -5,7 +5,7 @@ import play.Project._
 object ApplicationBuild extends Build {
 
   val appName         = "oncue-service"
-  val appVersion      = "1.0.2-SNAPSHOT"
+  val appVersion      = "1.0.3-SNAPSHOT"
 
   val appDependencies = Seq(
     // Add your project dependencies here,

--- a/oncue-tests/pom.xml
+++ b/oncue-tests/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>oncue</groupId>
 		<artifactId>oncue</artifactId>
-		<version>1.0.2-SNAPSHOT</version>
+		<version>1.0.3-SNAPSHOT</version>
 	</parent>
 	<artifactId>oncue-tests</artifactId>
 	<name>OnCue Tests</name>
@@ -25,43 +25,43 @@
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-common</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-backingstore</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-agent</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 			<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-worker</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-scheduler</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-client</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-timedjobs</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/oncue-tests/src/test/java/oncue/tests/load/DistributedThrottledLoadTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/load/DistributedThrottledLoadTest.java
@@ -21,9 +21,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 
 import oncue.agent.ThrottledAgent;
-import junit.framework.Assert;
-import oncue.agent.ThrottledAgent;
-import oncue.backingstore.RedisBackingStore;
 import oncue.common.messages.EnqueueJob;
 import oncue.common.messages.Job;
 import oncue.common.messages.Job.State;

--- a/oncue-tests/src/test/java/oncue/tests/redis/RedisBackingStoreTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/redis/RedisBackingStoreTest.java
@@ -39,6 +39,9 @@ import oncue.tests.workers.TestWorker;
 
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import redis.clients.jedis.Jedis;
@@ -46,6 +49,26 @@ import akka.actor.ActorRef;
 import akka.testkit.JavaTestKit;
 
 public class RedisBackingStoreTest extends ActorSystemTest {
+
+	private Jedis redis;
+
+	@Before
+	public void flushRedis() {
+		redis = RedisBackingStore.getConnection();
+		redis.flushAll();
+	}
+
+	@After
+	public void releaseRedisConnection() {
+		RedisBackingStore.releaseConnection(redis);
+	}
+
+	@AfterClass
+	public static void finalFlushRedis() {
+		Jedis redis = RedisBackingStore.getConnection();
+		redis.flushAll();
+		RedisBackingStore.releaseConnection(redis);
+	}
 
 	@Test
 	public void addScheduledJob() {
@@ -73,19 +96,18 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 
 				// Enqueue a job
 				scheduler.tell(new EnqueueJob(TestWorker.class.getName(), params), getRef());
-				Job job = expectMsgClass(Job.class);
+				final Job job = expectMsgClass(Job.class);
 
-				// Start an Agent
-				createAgent(system, new HashSet<String>(Arrays.asList(TestWorker.class.getName())), null);
+				// Check to see that the job is written as finished in redis
+				new AwaitCond() {
+					@Override
+					protected boolean cond() {
+						return redis.llen(RedisBackingStore.UNSCHEDULED_JOBS) > 0
+								&& redis.exists(getJobId(job.getId()));
+					}
+				};
 
-				// Wait for some progress
-				schedulerProbe.expectMsgClass(JobProgress.class);
-
-				// Check to see that scheduled job has been recorded in Redis
-				Jedis redis = RedisBackingStore.getConnection();
-				List<String> jobIDs = redis.brpop(0, RedisBackingStore.SCHEDULED_JOBS);
-				long jobId = new Long(jobIDs.get(1));
-				Job loadedJob = RedisBackingStore.loadJob(jobId, redis);
+				Job loadedJob = RedisBackingStore.loadJob(job.getId(), redis);
 
 				assertEquals(job.getId(), loadedJob.getId());
 				assertEquals(job.getEnqueuedAt().toString(), loadedJob.getEnqueuedAt().toString());
@@ -93,6 +115,27 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				assertEquals("Wrong number of parameters", 2, loadedJob.getParams().size());
 				assertEquals(job.getParams().get("month"), loadedJob.getParams().get("month"));
 				assertEquals(job.getParams().get("size"), loadedJob.getParams().get("size"));
+
+				// Start an Agent
+				createAgent(system, new HashSet<>(Arrays.asList(TestWorker.class.getName())), null);
+
+				// Check to see that the scheduled job has finished
+				new AwaitCond() {
+					@Override
+					protected boolean cond() {
+						// Wait for some progress
+						JobProgress progress = schedulerProbe.expectMsgClass(JobProgress.class);
+						return progress.getJob().getProgress() == 1.0;
+					}
+				};
+
+				// Check to see that the job goes into the completed jobs list
+				new AwaitCond() {
+					@Override
+					protected boolean cond() {
+						return redis.llen(RedisBackingStore.COMPLETED_JOBS) > 0;
+					}
+				};
 			}
 		};
 	}
@@ -111,10 +154,18 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 
 				// Enqueue a job
 				scheduler.tell(new EnqueueJob(TestWorker.class.getName(), params), getRef());
-				Job job = expectMsgClass(Job.class);
+				final Job job = expectMsgClass(Job.class);
+
+				// Check to see that the job is written as finished in redis
+				new AwaitCond() {
+					@Override
+					protected boolean cond() {
+						return redis.llen(RedisBackingStore.UNSCHEDULED_JOBS) > 0
+								&& redis.exists(getJobId(job.getId()));
+					}
+				};
 
 				// Check to see that unscheduled job has been recorded in Redis
-				Jedis redis = RedisBackingStore.getConnection();
 				List<String> jobIDs = redis.brpop(0, RedisBackingStore.UNSCHEDULED_JOBS);
 				long jobId = new Long(jobIDs.get(1));
 				Job loadedJob = RedisBackingStore.loadJob(jobId, redis);
@@ -125,8 +176,8 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				assertEquals("Wrong number of parameters", 2, loadedJob.getParams().size());
 				assertEquals(job.getParams().get("month"), loadedJob.getParams().get("month"));
 				assertEquals(job.getParams().get("size"), loadedJob.getParams().get("size"));
-				assertEquals("There should be no more jobs on the unscheduled queue", 0,
-						redis.llen(RedisBackingStore.UNSCHEDULED_JOBS).longValue());
+				assertEquals("There should be no more jobs on the unscheduled queue", 0, redis
+						.llen(RedisBackingStore.UNSCHEDULED_JOBS).longValue());
 			}
 		};
 	}
@@ -154,25 +205,41 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				scheduler.tell(new EnqueueJob(IncompetentTestWorker.class.getName()), getRef());
 				Job job = expectMsgClass(Job.class);
 
+				final String jobKey = getJobId(job.getId());
+
+				// Check to see that the scheduled job has been recorded in Redis
+				new AwaitCond() {
+					@Override
+					protected boolean cond() {
+						return redis.exists(jobKey);
+					}
+				};
+
 				// Start an Agent
-				createAgent(system, new HashSet<String>(Arrays.asList(IncompetentTestWorker.class.getName())), null);
+				createAgent(system,
+						new HashSet<>(Arrays.asList(IncompetentTestWorker.class.getName())), null);
 
 				// Expect a job failure message at the scheduler
 				JobFailed jobFailed = schedulerProbe.expectMsgClass(JobFailed.class);
 				Job failedJob = jobFailed.getJob();
 				assertEquals("Job IDs don't match", job.getId(), failedJob.getId());
-				assertTrue("Wrong exception type",
-						jobFailed.getJob().getErrorMessage().contains(ArithmeticException.class.getName()));
+				assertTrue(
+						"Wrong exception type",
+						jobFailed.getJob().getErrorMessage()
+								.contains(ArithmeticException.class.getName()));
 
 				expectNoMsg();
 
-				// Check to see that job failure has been recorded in Redis
-				Jedis redis = RedisBackingStore.getConnection();
-				final String jobKey = String.format(RedisBackingStore.JOB_KEY, job.getId());
+				new AwaitCond() {
+					@Override
+					protected boolean cond() {
+						return redis.llen(RedisBackingStore.FAILED_JOBS) > 0;
+					}
+				};
+
 				String state = redis.hget(jobKey, RedisBackingStore.JOB_STATE);
 				String errorMessage = redis.hget(jobKey, RedisBackingStore.JOB_ERROR_MESSAGE);
 				RedisBackingStore.releaseConnection(redis);
-
 				assertNotNull("No job state found", state);
 				assertEquals("The recorded state does not match the expected state", Job.State.FAILED.toString(), state);
 				assertTrue(errorMessage.contains(ArithmeticException.class.getName()));
@@ -204,7 +271,7 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				Job job = expectMsgClass(Job.class);
 
 				// Start an Agent
-				createAgent(system, new HashSet<String>(Arrays.asList(TestWorker.class.getName())), null);
+				createAgent(system, new HashSet<>(Arrays.asList(TestWorker.class.getName())), null);
 
 				// Expect a series of progress reports
 				double expectedProgress = 0;
@@ -217,17 +284,15 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				schedulerProbe.expectNoMsg();
 
 				// Check to see progress has been recorded in Redis
-				Jedis redis = RedisBackingStore.getConnection();
-				final String jobKey = String.format(RedisBackingStore.JOB_KEY, job.getId());
+				final String jobKey = getJobId(job.getId());
 				String progress = redis.hget(jobKey, RedisBackingStore.JOB_PROGRESS);
 
 				assertNotNull("No progress found", progress);
-				assertEquals("The recorded progress does not match the expected progress", 1.0, new Double(progress));
+				assertEquals("The recorded progress does not match the expected progress", 1.0,
+						new Double(progress));
 
 				// Check to see that only one job was persisted
 				assertEquals(1, redis.lrange(RedisBackingStore.COMPLETED_JOBS, 0, -1).size());
-
-				RedisBackingStore.releaseConnection(redis);
 			}
 		};
 	}
@@ -236,7 +301,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 	public void getCompletedJobs() {
 		new JavaTestKit(system) {
 			{
-				Jedis redis = RedisBackingStore.getConnection();
 				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
 				// Push a job into Redis
@@ -253,8 +317,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 
 				assertEquals(1, completedJobs.size());
 				assertEquals(job.getId(), completedJobs.get(0).getId());
-
-				RedisBackingStore.releaseConnection(redis);
 			}
 		};
 	}
@@ -263,7 +325,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 	public void getFailedJobs() {
 		new JavaTestKit(system) {
 			{
-				Jedis redis = RedisBackingStore.getConnection();
 				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
 				// Push a job into Redis
@@ -279,8 +340,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 
 				assertEquals(1, failedJobs.size());
 				assertEquals(job.getId(), failedJobs.get(0).getId());
-
-				RedisBackingStore.releaseConnection(redis);
 			}
 		};
 	}
@@ -289,12 +348,12 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 	public void restoreJobs() {
 		new JavaTestKit(system) {
 			{
-				Jedis redis = RedisBackingStore.getConnection();
 				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
 				// Push an unscheduled job into Redis
 				Job unscheduledJob = new Job(1, TestWorker.class.getName());
-				RedisBackingStore.persistJob(unscheduledJob, RedisBackingStore.UNSCHEDULED_JOBS, redis);
+				RedisBackingStore.persistJob(unscheduledJob, RedisBackingStore.UNSCHEDULED_JOBS,
+						redis);
 
 				// Push a scheduled job into Redis
 				Job scheduledJob = new Job(2, TestWorker.class.getName());
@@ -306,13 +365,12 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				// Check the set of restored jobs
 				assertTrue(restoredJobs.size() == 2);
 				for (Job job : restoredJobs) {
-					assertTrue(job.getId() == unscheduledJob.getId() || job.getId() == scheduledJob.getId());
+					assertTrue(job.getId() == unscheduledJob.getId()
+							|| job.getId() == scheduledJob.getId());
 				}
 
 				// Make sure no scheduled jobs remain
 				assertEquals(0, redis.lrange(RedisBackingStore.SCHEDULED_JOBS, 0, -1).size());
-
-				RedisBackingStore.releaseConnection(redis);
 			}
 		};
 	}
@@ -333,10 +391,8 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 		job.setRerun(true);
 		job.setStartedAt(testTime);
 		job.setCompletedAt(testTime);
-		Jedis redis = RedisBackingStore.getConnection();
 		RedisBackingStore.persistJob(job, "test_queue", redis);
 		Job loadedJob = RedisBackingStore.loadJob(0, redis);
-		RedisBackingStore.releaseConnection(redis);
 
 		assertNotNull("Expected 'enqueued at' timestamp", job.getEnqueuedAt());
 		assertNotNull("Expected 'started at' timestamp", job.getStartedAt());
@@ -357,11 +413,9 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 	@Test
 	public void cleanUpJobsReturnsCorrectCleanedUpJobCount() {
 		new JavaTestKit(system) {
-			private Jedis redis;
 			private RedisBackingStore backingStore;
 
 			{
-				redis = RedisBackingStore.getConnection();
 				backingStore = new RedisBackingStore(system, settings);
 
 				// Push expired jobs into redis
@@ -379,8 +433,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				assertFalse(redis.exists(getJobId(1)));
 				assertFalse(redis.exists(getJobId(2)));
 				assertFalse(redis.exists(getJobId(3)));
-
-				RedisBackingStore.releaseConnection(redis);
 			}
 
 			private void persistTestJob(int jobNumber, DateTime completionTime, boolean failed) {
@@ -405,11 +457,9 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 	@Test
 	public void removeJobById() {
 		new JavaTestKit(system) {
-			private Jedis redis;
 			private RedisBackingStore backingStore;
 
 			{
-				redis = RedisBackingStore.getConnection();
 				backingStore = new RedisBackingStore(system, settings);
 
 				Job job = new Job(1, TestWorker.class.getName());
@@ -420,8 +470,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 
 				backingStore.removeJobById(job.getId(), redis);
 				assertFalse(redis.exists(jobId));
-
-				RedisBackingStore.releaseConnection(redis);
 			}
 
 		};
@@ -431,7 +479,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 	public void removeCompletedJobById() {
 		new JavaTestKit(system) {
 			{
-				Jedis redis = RedisBackingStore.getConnection();
 				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
 				// Push a job into Redis
@@ -445,13 +492,12 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				// Remove the scheduled job
 				backingStore.removeCompletedJobById(job.getId());
 
+				// Assert that the job no longer exists
 				assertFalse(redis.exists(getJobId(job.getId())));
 
 				// Check scheduled list in Redis
 				assertEquals("Expected no jobs in the completed jobs list", 0,
 						redis.lrange(RedisBackingStore.COMPLETED_JOBS, 0, -1).size());
-
-				RedisBackingStore.releaseConnection(redis);
 			}
 		};
 	}
@@ -460,7 +506,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 	public void removeFailedJobById() {
 		new JavaTestKit(system) {
 			{
-				Jedis redis = RedisBackingStore.getConnection();
 				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
 				// Push a job into Redis
@@ -474,13 +519,12 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				// Remove the scheduled job
 				backingStore.removeFailedJobById(job.getId());
 
+				// Assert that the job no longer exists
 				assertFalse(redis.exists(getJobId(job.getId())));
 
 				// Check scheduled list in Redis
 				assertEquals("Expected no jobs in the failed jobs list", 0,
 						redis.lrange(RedisBackingStore.FAILED_JOBS, 0, -1).size());
-
-				RedisBackingStore.releaseConnection(redis);
 			}
 		};
 	}
@@ -489,7 +533,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 	public void removeScheduledJobById() {
 		new JavaTestKit(system) {
 			{
-				Jedis redis = RedisBackingStore.getConnection();
 				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
 				// Push a job into Redis
@@ -501,13 +544,12 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				// Remove the scheduled job
 				backingStore.removeScheduledJobById(job.getId());
 
-				assertFalse(redis.exists(getJobId(job.getId())));
+				// Assert that the job still exists
+				assertTrue(redis.exists(getJobId(job.getId())));
 
 				// Check scheduled list in Redis
 				assertEquals("Expected no jobs in the scheduled jobs list", 0,
 						redis.lrange(RedisBackingStore.SCHEDULED_JOBS, 0, -1).size());
-
-				RedisBackingStore.releaseConnection(redis);
 			}
 		};
 	}
@@ -516,7 +558,6 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 	public void removeUnscheduledJobById() {
 		new JavaTestKit(system) {
 			{
-				Jedis redis = RedisBackingStore.getConnection();
 				RedisBackingStore backingStore = new RedisBackingStore(system, settings);
 
 				// Push a job into Redis
@@ -528,14 +569,12 @@ public class RedisBackingStoreTest extends ActorSystemTest {
 				// Remove the scheduled job
 				backingStore.removeUnscheduledJobById(job.getId());
 
-				assertFalse(redis.exists(getJobId(job.getId())));
+				// Assert that the job still exists
+				assertTrue(redis.exists(getJobId(job.getId())));
 
 				// Check scheduled list in Redis
 				assertEquals("Expected no jobs in the unscheduled jobs list", 0,
 						redis.lrange(RedisBackingStore.UNSCHEDULED_JOBS, 0, -1).size());
-
-				RedisBackingStore.releaseConnection(redis);
-
 			}
 		};
 	}

--- a/oncue-timedjobs/pom.xml
+++ b/oncue-timedjobs/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>oncue</groupId>
     <artifactId>oncue</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>oncue-timedjobs</artifactId>
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>oncue</groupId>
       <artifactId>oncue-common</artifactId>
-      <version>1.0.2-SNAPSHOT</version>
+      <version>1.0.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>

--- a/oncue-worker/pom.xml
+++ b/oncue-worker/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>oncue</groupId>
     <artifactId>oncue</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
   </parent>
 
   <groupId>oncue</groupId>
@@ -17,12 +17,12 @@
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-common</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>oncue</groupId>
 			<artifactId>oncue-client</artifactId>
-			<version>1.0.2-SNAPSHOT</version>
+			<version>1.0.3-SNAPSHOT</version>
 		</dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>oncue</groupId>
     <artifactId>oncue</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>OnCue</name>


### PR DESCRIPTION
Fixes a bug where redis keys with "oncue:jobs:<job_id>" never got removed from redis. This is the job of the clean up method in `AbstractScheduler`. This resulted in expired completed/failed jobs slowly built up in redis.