### PR TITLE
Fix @link references to non-existent classes causing javadoc plugin t…

### DIFF
--- a/oncue-agent/src/main/java/oncue/agent/CapacityAgent.java
+++ b/oncue-agent/src/main/java/oncue/agent/CapacityAgent.java
@@ -19,15 +19,15 @@ import oncue.common.messages.CapacityWorkRequest;
 import oncue.common.messages.Job;
 
 /**
- * This class is intended to be used with the {@link CapacityScheduler}. It models an agent as a
- * hole of a certain size, indicated by the "memory" priorty. Each job that is sent to the agent
- * will have a "memory" value, and the agent will continuously bite off work to do until it has no
- * more "memory" capacity left, and will execute all jobs in parallel. It will always consume as
- * many jobs as possible and it will do it in the order specified by the
- * {@link PriorityJobComparator}. This means that a larger job that cannot be completed at the time
- * may be skipped in favour of a lower priority lower "memory" job. Users must be careful not to
- * provide a continuous stream of low "memory" jobs that could prevent the timely execution of a
- * high "memory" job.
+ * This class is intended to be used with the <code>oncue.scheduler.CapacityScheduler
+ * </code>}. It models an agent as a hole of a certain size, indicated by the "memory" priorty. Each
+ * job that is sent to the agent will have a "memory" value, and the agent will continuously bite
+ * off work to do until it has no more "memory" capacity left, and will execute all jobs in
+ * parallel. It will always consume as many jobs as possible and it will do it in the order
+ * specified by the <code>oncue.scheduler.PriorityJobComparator</code>. This means that a larger job
+ * that cannot be completed at the time may be skipped in favour of a lower priority lower "memory"
+ * job. Users must be careful not to provide a continuous stream of low "memory" jobs that could
+ * prevent the timely execution of a high "memory" job.
  * 
  * The total "memory" available to the agent must be configured with the configuration propery
  * "oncue.agent.capacity-agent.total-memory". The Agent will crash on startup if this is not

--- a/oncue-scheduler/src/main/java/oncue/scheduler/CapacityScheduler.java
+++ b/oncue-scheduler/src/main/java/oncue/scheduler/CapacityScheduler.java
@@ -37,7 +37,7 @@ import com.typesafe.config.ConfigObject;
  * job does not provide a priority, it is assumed to be 0 (low priority).
  * 
  * This scheduler will only provide as many jobs to an agent as it declares it has free memory. See
- * the documentation for {@link CapacityAgent} for more information.
+ * the documentation for <code>oncue.agent.CapacityAgent</code> for more information.
  * 
  * This scheduler also allows specification of a job that cannot be run in parallel. The worker type
  * must be specified with "oncue.scheduler.capacity-scheduler.worker-type" and the parameter for

--- a/oncue-scheduler/src/main/java/oncue/scheduler/Schedule.java
+++ b/oncue-scheduler/src/main/java/oncue/scheduler/Schedule.java
@@ -27,8 +27,7 @@ import oncue.common.messages.WorkResponse;
 import akka.actor.ActorRef;
 
 /**
- * A Schedule describes the set of {@linkplain Job}s assigned to each
- * {@linkplain Agent}.
+ * A Schedule describes the set of {@linkplain Job}s assigned to each agent
  */
 public class Schedule {
 

--- a/oncue-scheduler/src/main/java/oncue/scheduler/ScheduledJobs.java
+++ b/oncue-scheduler/src/main/java/oncue/scheduler/ScheduledJobs.java
@@ -1,17 +1,15 @@
 /*******************************************************************************
  * Copyright 2013 Michael Marconi
  * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  ******************************************************************************/
 package oncue.scheduler;
 
@@ -20,17 +18,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import oncue.backingstore.BackingStore;
-import oncue.common.messages.Agent;
-import oncue.common.messages.Job;
-import oncue.scheduler.exceptions.RemoveScheduleJobException;
-
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 
+import oncue.backingstore.BackingStore;
+import oncue.common.messages.Job;
+import oncue.scheduler.exceptions.RemoveScheduleJobException;
+
 /**
- * An encapsulated map of {@linkplain Job}s to the {@linkplain Agent}s they have
- * been scheduled against.
+ * An encapsulated map of {@linkplain Job}s to the agents they have been scheduled against.
  */
 public class ScheduledJobs {
 
@@ -41,8 +37,7 @@ public class ScheduledJobs {
 	private Map<String, List<Job>> scheduledJobs = new HashMap<String, List<Job>>();
 
 	/**
-	 * @param backingStore
-	 *            is an instance of {@linkplain BackingStore}
+	 * @param backingStore is an instance of {@linkplain BackingStore}
 	 */
 	public ScheduledJobs(BackingStore backingStore) {
 		this.backingStore = backingStore;
@@ -51,10 +46,8 @@ public class ScheduledJobs {
 	/**
 	 * Assign a list of jobs to an agent
 	 * 
-	 * @param agent
-	 *            is the {@linkplain Agent} to which the jobs are being assigned
-	 * @param jobs
-	 *            is the list of {@linkplain Jobs}s to assign to the agent
+	 * @param agent is the agent to which the jobs are being assigned
+	 * @param jobs is the list of {@linkplain Job}s to assign to the agent
 	 */
 	public void addJobs(String agent, List<Job> jobs) {
 		List<Job> assignedJobs = scheduledJobs.get(agent);
@@ -83,8 +76,7 @@ public class ScheduledJobs {
 	/**
 	 * Get the list of jobs associated with this agent
 	 * 
-	 * @param agent
-	 *            is the {@linkplain Agent} the jobs are associated with
+	 * @param agent is the agent the jobs are associated with
 	 * @return a list of {@linkplain Job}s associated with the agent
 	 */
 	public List<Job> getJobs(String agent) {
@@ -96,13 +88,11 @@ public class ScheduledJobs {
 	}
 
 	/**
-	 * Update the state and progress of a scheduled job, usually in response to
-	 * work done on the job.
+	 * Update the state and progress of a scheduled job, usually in response to work done on the
+	 * job.
 	 * 
-	 * @param job
-	 *            contains the updates
-	 * @param agent
-	 *            is where the work is being done
+	 * @param job contains the updates
+	 * @param agent is where the work is being done
 	 */
 	public void updateJob(Job job, String agent) {
 		List<Job> jobs = getJobs(agent);
@@ -117,8 +107,7 @@ public class ScheduledJobs {
 	/**
 	 * Remove a job associated with an agent
 	 * 
-	 * @param job
-	 *            is the {@linkplain Job} to remove
+	 * @param jobId is the {@linkplain Job} ID to remove
 	 * 
 	 * @throws RemoveScheduleJobException
 	 */

--- a/oncue-scheduler/src/main/java/oncue/scheduler/ThrottledScheduler.java
+++ b/oncue-scheduler/src/main/java/oncue/scheduler/ThrottledScheduler.java
@@ -27,7 +27,7 @@ import oncue.common.messages.ThrottledWorkRequest;
  * This implementation of {@linkplain AbstractScheduler} employs a throttling
  * strategy to ensure that agents are never overwhelmed with work.
  * 
- * A {@linkplain ThrottledAgent} will send a {@linkplain ThrottledWorkRequest},
+ * A <code>oncue.agent.ThrottledAgent</code> will send a {@linkplain ThrottledWorkRequest},
  * stating the number of jobs it is able to process in parallel. This scheduler
  * will pop just enough jobs off the queue to satisfy this throttled request for
  * work.


### PR DESCRIPTION
…o fail

Currently the maven javadoc plugin fails.

This still won't compile on Java 8 unfortunately due to some scala incompatibilities. Play2 needs to be updated before this can happen.