### PR TITLE
Change target JDK to 1.8 and disable maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.7</java.version>
+        <java.version>1.8</java.version>
     </properties>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -130,19 +130,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadoc</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-eclipse-plugin</artifactId>
                 <version>2.9</version>
                 <configuration>


### PR DESCRIPTION
This changes the target version to JDK8 and disables the javadoc plugin.

Disabling the javadoc plugin is only necessary as a deliberate choice to not fix the javadoc generation errors that happen when compiling under JDK8 without explicitly disabling javadoc plugin. It can be re-enabled when we have time to fix the underlying issue.