### PR TITLE
Fix Jedis connection pool leak in OnCue Service

### DIFF
--- a/oncue-tests/src/test/java/oncue/tests/base/DistributedActorSystemTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/base/DistributedActorSystemTest.java
@@ -1,32 +1,26 @@
 /*******************************************************************************
  * Copyright 2013 Michael Marconi
  * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  ******************************************************************************/
 package oncue.tests.base;
 
 import java.util.Set;
 
-import oncue.agent.AbstractAgent;
-import oncue.backingstore.RedisBackingStore;
-import oncue.common.settings.Settings;
-import oncue.common.settings.SettingsProvider;
-import oncue.scheduler.AbstractScheduler;
-
 import org.junit.After;
 import org.junit.Before;
 
-import redis.clients.jedis.Jedis;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
 import akka.actor.Actor;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -34,31 +28,40 @@ import akka.actor.Props;
 import akka.actor.UntypedActorFactory;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
-
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
+import oncue.agent.AbstractAgent;
+import oncue.backingstore.RedisBackingStore;
+import oncue.backingstore.RedisBackingStore.RedisConnection;
+import oncue.common.settings.Settings;
+import oncue.common.settings.SettingsProvider;
+import oncue.scheduler.AbstractScheduler;
 
 public abstract class DistributedActorSystemTest {
 
 	protected Config serviceConfig;
+
 	protected ActorSystem serviceSystem;
+
 	protected Settings serviceSettings;
+
 	protected LoggingAdapter serviceLog;
 
 	protected Config agentConfig;
+
 	protected ActorSystem agentSystem;
+
 	protected Settings agentSettings;
+
 	protected LoggingAdapter agentLog;
 
 	/**
 	 * Create an agent component, with a set of workers and an optional probe
 	 * 
-	 * @param probe
-	 *            can be null
+	 * @param probe can be null
 	 */
 	@SuppressWarnings("serial")
 	public ActorRef createAgent(final Set<String> workers, final ActorRef probe) {
 		return agentSystem.actorOf(new Props(new UntypedActorFactory() {
+
 			@Override
 			public Actor create() throws Exception {
 				AbstractAgent agent = (AbstractAgent) Class.forName(agentSettings.AGENT_CLASS)
@@ -73,22 +76,23 @@ public abstract class DistributedActorSystemTest {
 	/**
 	 * Create a scheduler component, with an optional probe
 	 * 
-	 * @param probe
-	 *            can be null
+	 * @param probe can be null
 	 */
 	@SuppressWarnings("serial")
 	public ActorRef createScheduler(final ActorRef probe) {
 		return serviceSystem.actorOf(new Props(new UntypedActorFactory() {
+
 			@Override
 			public Actor create() throws Exception {
 				Class<?> schedulerClass = Class.forName(serviceSettings.SCHEDULER_CLASS);
 				Class<?> backingStoreClass = null;
 				if (serviceSettings.SCHEDULER_BACKING_STORE_CLASS != null)
-					backingStoreClass = Class.forName(serviceSettings.SCHEDULER_BACKING_STORE_CLASS);
+					backingStoreClass = Class
+							.forName(serviceSettings.SCHEDULER_BACKING_STORE_CLASS);
 
 				@SuppressWarnings("rawtypes")
-				AbstractScheduler scheduler = (AbstractScheduler) schedulerClass.getConstructor(Class.class)
-						.newInstance(backingStoreClass);
+				AbstractScheduler scheduler = (AbstractScheduler) schedulerClass
+						.getConstructor(Class.class).newInstance(backingStoreClass);
 				if (probe != null)
 					scheduler.injectProbe(probe);
 				return scheduler;
@@ -99,14 +103,15 @@ public abstract class DistributedActorSystemTest {
 	@Before
 	public void startActorSystems() {
 		/*
-		 * Load configuration specific to this test and fall back to the
-		 * reference configuration
+		 * Load configuration specific to this test and fall back to the reference configuration
 		 */
 		serviceConfig = ConfigFactory.load();
-		serviceConfig = ConfigFactory.load(getClass().getSimpleName() + "-Service").withFallback(serviceConfig);
+		serviceConfig = ConfigFactory.load(getClass().getSimpleName() + "-Service")
+				.withFallback(serviceConfig);
 
 		agentConfig = ConfigFactory.load();
-		agentConfig = ConfigFactory.load(getClass().getSimpleName() + "-Agent").withFallback(agentConfig);
+		agentConfig = ConfigFactory.load(getClass().getSimpleName() + "-Agent")
+				.withFallback(agentConfig);
 
 		serviceSystem = ActorSystem.create("oncue-service", serviceConfig);
 		serviceSettings = SettingsProvider.SettingsProvider.get(serviceSystem);
@@ -131,8 +136,8 @@ public abstract class DistributedActorSystemTest {
 	@Before
 	@After
 	public void cleanRedis() {
-		Jedis redis = RedisBackingStore.getConnection();
-		redis.flushDB();
-		RedisBackingStore.releaseConnection(redis);
+		try (RedisConnection redis = new RedisBackingStore.RedisConnection()) {
+			redis.flushDB();
+		}
 	}
 }


### PR DESCRIPTION
If an exception happened while OnCue service was connecting to Redis,
the connection would never be released into the pool. This would cause
connection starvation and, ultimately, unresponsiveness from OnCue
Service. This uses JDK7's AutoCloseable to ensure that all connections
get released to the pool.