### PR TITLE
 Bump the jedis (redis) library from 2.0.0 to 2.8.1 

### DIFF
--- a/oncue-backingstore/pom.xml
+++ b/oncue-backingstore/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>redis.clients</groupId>
       <artifactId>jedis</artifactId>
-      <version>2.0.0</version>
+      <version>2.8.1</version>
       <type>jar</type>
       <scope>compile</scope>
     </dependency>

--- a/oncue-tests/src/test/java/oncue/tests/base/DistributedActorSystemTest.java
+++ b/oncue-tests/src/test/java/oncue/tests/base/DistributedActorSystemTest.java
@@ -1,32 +1,26 @@
 /*******************************************************************************
  * Copyright 2013 Michael Marconi
  * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  ******************************************************************************/
 package oncue.tests.base;
 
 import java.util.Set;
 
-import oncue.agent.AbstractAgent;
-import oncue.backingstore.RedisBackingStore;
-import oncue.common.settings.Settings;
-import oncue.common.settings.SettingsProvider;
-import oncue.scheduler.AbstractScheduler;
-
 import org.junit.After;
 import org.junit.Before;
 
-import redis.clients.jedis.Jedis;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
 import akka.actor.Actor;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -34,31 +28,40 @@ import akka.actor.Props;
 import akka.actor.UntypedActorFactory;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
-
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
+import oncue.agent.AbstractAgent;
+import oncue.backingstore.RedisBackingStore;
+import oncue.backingstore.RedisBackingStore.RedisConnection;
+import oncue.common.settings.Settings;
+import oncue.common.settings.SettingsProvider;
+import oncue.scheduler.AbstractScheduler;
 
 public abstract class DistributedActorSystemTest {
 
 	protected Config serviceConfig;
+
 	protected ActorSystem serviceSystem;
+
 	protected Settings serviceSettings;
+
 	protected LoggingAdapter serviceLog;
 
 	protected Config agentConfig;
+
 	protected ActorSystem agentSystem;
+
 	protected Settings agentSettings;
+
 	protected LoggingAdapter agentLog;
 
 	/**
 	 * Create an agent component, with a set of workers and an optional probe
 	 * 
-	 * @param probe
-	 *            can be null
+	 * @param probe can be null
 	 */
 	@SuppressWarnings("serial")
 	public ActorRef createAgent(final Set<String> workers, final ActorRef probe) {
 		return agentSystem.actorOf(new Props(new UntypedActorFactory() {
+
 			@Override
 			public Actor create() throws Exception {
 				AbstractAgent agent = (AbstractAgent) Class.forName(agentSettings.AGENT_CLASS)
@@ -73,22 +76,23 @@ public abstract class DistributedActorSystemTest {
 	/**
 	 * Create a scheduler component, with an optional probe
 	 * 
-	 * @param probe
-	 *            can be null
+	 * @param probe can be null
 	 */
 	@SuppressWarnings("serial")
 	public ActorRef createScheduler(final ActorRef probe) {
 		return serviceSystem.actorOf(new Props(new UntypedActorFactory() {
+
 			@Override
 			public Actor create() throws Exception {
 				Class<?> schedulerClass = Class.forName(serviceSettings.SCHEDULER_CLASS);
 				Class<?> backingStoreClass = null;
 				if (serviceSettings.SCHEDULER_BACKING_STORE_CLASS != null)
-					backingStoreClass = Class.forName(serviceSettings.SCHEDULER_BACKING_STORE_CLASS);
+					backingStoreClass = Class
+							.forName(serviceSettings.SCHEDULER_BACKING_STORE_CLASS);
 
 				@SuppressWarnings("rawtypes")
-				AbstractScheduler scheduler = (AbstractScheduler) schedulerClass.getConstructor(Class.class)
-						.newInstance(backingStoreClass);
+				AbstractScheduler scheduler = (AbstractScheduler) schedulerClass
+						.getConstructor(Class.class).newInstance(backingStoreClass);
 				if (probe != null)
 					scheduler.injectProbe(probe);
 				return scheduler;
@@ -99,14 +103,15 @@ public abstract class DistributedActorSystemTest {
 	@Before
 	public void startActorSystems() {
 		/*
-		 * Load configuration specific to this test and fall back to the
-		 * reference configuration
+		 * Load configuration specific to this test and fall back to the reference configuration
 		 */
 		serviceConfig = ConfigFactory.load();
-		serviceConfig = ConfigFactory.load(getClass().getSimpleName() + "-Service").withFallback(serviceConfig);
+		serviceConfig = ConfigFactory.load(getClass().getSimpleName() + "-Service")
+				.withFallback(serviceConfig);
 
 		agentConfig = ConfigFactory.load();
-		agentConfig = ConfigFactory.load(getClass().getSimpleName() + "-Agent").withFallback(agentConfig);
+		agentConfig = ConfigFactory.load(getClass().getSimpleName() + "-Agent")
+				.withFallback(agentConfig);
 
 		serviceSystem = ActorSystem.create("oncue-service", serviceConfig);
 		serviceSettings = SettingsProvider.SettingsProvider.get(serviceSystem);
@@ -131,8 +136,8 @@ public abstract class DistributedActorSystemTest {
 	@Before
 	@After
 	public void cleanRedis() {
-		Jedis redis = RedisBackingStore.getConnection();
-		redis.flushDB();
-		RedisBackingStore.releaseConnection(redis);
+		try (RedisConnection redis = new RedisBackingStore.RedisConnection()) {
+			redis.flushDB();
+		}
 	}
 }


### PR DESCRIPTION
This requires https://github.com/michaelmarconi/oncue/pull/109.

It gives us things such as (from the release notes page[1]):
- "And lots of other wonderful things!!!"
- Several new redis commands added to the interface (currently unused by OnCue)
- The underlying connection pool software[2] has been upgraded
- Clustered redis support (currently unused by OnCue)
- Jedis and pool classes now implement Closeable
- "General bugfixes and improvements"

[1] - https://github.com/xetorthio/jedis/releases?after=jedis-2.3.0
[2] - http://commons.apache.org/proper/commons-pool/

I mentioned in https://github.com/michaelmarconi/oncue/pull/108 that I had some test failures relating to redis when running locally. This pull request fixes those failures.

There are two code changes on our part:
- The method for returning the connection was deprecated in favour of `close()` on the pool-allocated object, which now returns itself to the pool. This has been updated since we would be trying to return things to the pool twice
- The transaction resource is now closeable and has been managed with try-with-resources.